### PR TITLE
Fix: add validation for dataSubjectConsent checkbox

### DIFF
--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -45,6 +45,12 @@ const validationMetadata = {
   termsAndConditions: Yup.boolean()
     .required('Required')
     .isTrue('Please agree to the Terms and Conditions.'),
+  dataSubjectConsent: Yup.boolean().when('type', {
+    is: 'dataset',
+    then: Yup.boolean()
+      .required('Required')
+      .isTrue("Please confirm the data subject's consent.")
+  }),
   usesConsumerParameters: Yup.boolean(),
   consumerParameters: Yup.array().when('type', {
     is: 'algorithm',


### PR DESCRIPTION
adds validation for the `dataSubjectConsent` checkbox, so it is required on publish form