### PR TITLE
multiple services - consuming support

### DIFF
--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -137,11 +137,7 @@ function AssetProvider({
     const accessDetails = await Promise.all(
       asset.services.map((service: Service) =>
         getAccessDetails(
-          signer,
-          asset.offchain?.stats.services.find(
-            (s) => s.serviceId === service.id
-          ),
-          accountId
+          asset.offchain?.stats.services.find((s) => s.serviceId === service.id)
         )
       )
     )

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -18,7 +18,7 @@ import { useMarketMetadata } from './MarketMetadata'
 import { assetStateToString } from '@utils/assetState'
 import { isValidDid } from '@utils/ddo'
 import { useAddressConfig } from '@hooks/useAddressConfig'
-import { useAccount, useNetwork, useSigner } from 'wagmi'
+import { useAccount, useNetwork } from 'wagmi'
 
 export interface AssetProviderValue {
   isInPurgatory: boolean
@@ -47,7 +47,6 @@ function AssetProvider({
   const { appConfig } = useMarketMetadata()
   const { address: accountId } = useAccount()
   const { chain } = useNetwork()
-  const { data: signer } = useSigner()
 
   const { isDDOWhitelisted } = useAddressConfig()
   const [isInPurgatory, setIsInPurgatory] = useState(false)
@@ -147,14 +146,7 @@ function AssetProvider({
       accessDetails
     }))
     LoggerInstance.log(`[asset] Got access details for ${did}`, accessDetails)
-  }, [
-    accountId,
-    asset?.chainId,
-    asset?.offchain?.stats.services,
-    asset?.services,
-    did,
-    signer
-  ])
+  }, [asset?.chainId, asset?.offchain?.stats.services, asset?.services, did])
 
   // -----------------------------------
   // 1. Get and set asset based on passed DID

--- a/src/@context/MarketMetadata/index.tsx
+++ b/src/@context/MarketMetadata/index.tsx
@@ -85,7 +85,7 @@ function MarketMetadataProvider({
           address: process.env.NEXT_PUBLIC_OCEAN_TOKEN_ADDRESS,
           decimals: 18,
           symbol: 'OCEAN',
-          name: 'Ocean token'
+          name: 'Ocean Token'
         }
       ]
       setApprovedBaseTokens(approvedTokensList)

--- a/src/@context/MarketMetadata/index.tsx
+++ b/src/@context/MarketMetadata/index.tsx
@@ -78,7 +78,16 @@ function MarketMetadataProvider({
   // -----------------------------------
   const getApprovedBaseTokens = useCallback(async (chainId: number) => {
     try {
-      const approvedTokensList = await getOpcsApprovedTokens(chainId)
+      // TODO Doesn't work with subgraph anymore
+      // const approvedTokensList = await getOpcsApprovedTokens(chainId)
+      const approvedTokensList = [
+        {
+          address: process.env.NEXT_PUBLIC_OCEAN_TOKEN_ADDRESS,
+          decimals: 18,
+          symbol: 'OCEAN',
+          name: 'Ocean token'
+        }
+      ]
       setApprovedBaseTokens(approvedTokensList)
       LoggerInstance.log(
         '[MarketMetadata] Approved baseTokens',

--- a/src/@types/AssetExtended.d.ts
+++ b/src/@types/AssetExtended.d.ts
@@ -3,10 +3,34 @@ import { Asset } from '@oceanprotocol/lib'
 // declaring into global scope to be able to use this as
 // ambiant types despite the above imports
 declare global {
+  interface ServicePrice {
+    type: 'fixedrate' | 'dispenser'
+    price: string
+    contract: string
+    token?: TokenInfo
+    exchangeId?: string
+  }
+
+  interface ServiceStat {
+    datatokenAddress: string
+    name: string
+    symbol: string
+    serviceId: string
+    orders: number
+    prices: ServicePrice[]
+  }
+
+  interface OffChain {
+    stats: {
+      services: ServiceStat[]
+    }
+  }
+
   interface AssetExtended extends Asset {
-    accessDetails?: AccessDetails
+    accessDetails?: AccessDetails[]
     views?: number
     metadata: MetadataExtended
     services: ServiceExtended[]
+    offchain?: OffChain // TODO - in future it will be directly included in Asset type in @oceanprotocol/lib
   }
 }

--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -115,9 +115,7 @@ export async function getOrderPriceAndFees(
  * @returns {Promise<AccessDetails>}
  */
 export async function getAccessDetails(
-  signer: Signer,
-  serviceStat: ServiceStat | undefined,
-  accountId: string
+  serviceStat: ServiceStat | undefined
 ): Promise<AccessDetails> {
   const accessDetails: AccessDetails = {
     type: 'NOT_SUPPORTED',

--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -1,6 +1,5 @@
 import {
   AssetPrice,
-  Datatoken,
   getErrorMessage,
   LoggerInstance,
   ProviderFees,

--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -1,15 +1,11 @@
-import { gql, OperationResult } from 'urql'
-import { fetchData, getQueryContext } from './subgraph'
-import {
-  TokenPriceQuery,
-  TokenPriceQuery_token as TokenPrice
-} from '../@types/subgraph/TokenPriceQuery'
 import {
   AssetPrice,
+  Datatoken,
   getErrorMessage,
   LoggerInstance,
   ProviderFees,
   ProviderInstance,
+  Service,
   ZERO_ADDRESS
 } from '@oceanprotocol/lib'
 import { getFixedBuyPrice } from './ocean/fixedRateExchange'
@@ -22,143 +18,6 @@ import {
 import { Signer } from 'ethers'
 import { toast } from 'react-toastify'
 
-const tokenPriceQuery = gql`
-  query TokenPriceQuery($datatokenId: ID!, $account: String) {
-    token(id: $datatokenId) {
-      id
-      symbol
-      name
-      templateId
-      publishMarketFeeAddress
-      publishMarketFeeToken
-      publishMarketFeeAmount
-      orders(
-        where: { payer: $account }
-        orderBy: createdTimestamp
-        orderDirection: desc
-      ) {
-        tx
-        serviceIndex
-        createdTimestamp
-        providerFee
-        reuses(orderBy: createdTimestamp, orderDirection: desc) {
-          id
-          caller
-          createdTimestamp
-          tx
-          block
-        }
-      }
-      dispensers {
-        id
-        active
-        isMinter
-        maxBalance
-        token {
-          id
-          name
-          symbol
-        }
-      }
-      fixedRateExchanges {
-        id
-        exchangeId
-        price
-        publishMarketSwapFee
-        baseToken {
-          symbol
-          name
-          address
-          decimals
-        }
-        datatoken {
-          symbol
-          name
-          address
-        }
-        active
-      }
-    }
-  }
-`
-
-function getAccessDetailsFromTokenPrice(
-  tokenPrice: TokenPrice,
-  timeout?: number
-): AccessDetails {
-  const accessDetails = {} as AccessDetails
-  // Return early when no supported pricing schema found.
-  if (
-    tokenPrice?.dispensers?.length === 0 &&
-    tokenPrice?.fixedRateExchanges?.length === 0
-  ) {
-    accessDetails.type = 'NOT_SUPPORTED'
-    return accessDetails
-  }
-
-  if (tokenPrice?.orders?.length > 0) {
-    const order = tokenPrice.orders[0]
-    const providerFees: ProviderFees = order?.providerFee
-      ? JSON.parse(order.providerFee)
-      : null
-    accessDetails.validProviderFees =
-      providerFees?.validUntil &&
-      Date.now() / 1000 < Number(providerFees?.validUntil)
-        ? providerFees
-        : null
-    const reusedOrder = order?.reuses?.length > 0 ? order.reuses[0] : null
-    // asset is owned if there is an order and asset has timeout 0 (forever) or if the condition is valid
-    accessDetails.isOwned =
-      timeout === 0 || Date.now() / 1000 - order?.createdTimestamp < timeout
-    // the last valid order should be the last reuse order tx id if there is one
-    accessDetails.validOrderTx = reusedOrder?.tx || order?.tx
-  }
-  accessDetails.templateId =
-    typeof tokenPrice.templateId === 'string'
-      ? parseInt(tokenPrice.templateId)
-      : tokenPrice.templateId
-  // TODO: fetch order fee from sub query
-  accessDetails.publisherMarketOrderFee = tokenPrice?.publishMarketFeeAmount
-
-  // free is always the best price
-  if (tokenPrice?.dispensers?.length > 0) {
-    const dispenser = tokenPrice.dispensers[0]
-    accessDetails.type = 'free'
-    accessDetails.addressOrId = dispenser.token.id
-
-    accessDetails.price = '0'
-    accessDetails.isPurchasable = dispenser.active
-    accessDetails.datatoken = {
-      address: dispenser.token.id,
-      name: dispenser.token.name,
-      symbol: dispenser.token.symbol
-    }
-  }
-
-  // checking for fixed price
-  if (tokenPrice?.fixedRateExchanges?.length > 0) {
-    const fixed = tokenPrice.fixedRateExchanges[0]
-    accessDetails.type = 'fixed'
-    accessDetails.addressOrId = fixed.exchangeId
-    accessDetails.price = fixed.price
-    // in theory we should check dt balance here, we can skip this because in the market we always create fre with minting capabilities.
-    accessDetails.isPurchasable = fixed.active
-    accessDetails.baseToken = {
-      address: fixed.baseToken.address,
-      name: fixed.baseToken.name,
-      symbol: fixed.baseToken.symbol,
-      decimals: fixed.baseToken.decimals
-    }
-    accessDetails.datatoken = {
-      address: fixed.datatoken.address,
-      name: fixed.datatoken.name,
-      symbol: fixed.datatoken.symbol
-    }
-  }
-
-  return accessDetails
-}
-
 /**
  * This will be used to get price including fees before ordering
  * @param {AssetExtended} asset
@@ -166,12 +25,14 @@ function getAccessDetailsFromTokenPrice(
  */
 export async function getOrderPriceAndFees(
   asset: AssetExtended,
+  service: Service,
+  accessDetails: AccessDetails,
   accountId: string,
   signer?: Signer,
   providerFees?: ProviderFees
 ): Promise<OrderPriceAndFees> {
   const orderPriceAndFee = {
-    price: String(asset?.stats?.price?.value || '0'),
+    price: accessDetails.price || '0',
     publisherMarketOrderFee: publisherMarketOrderFee || '0',
     publisherMarketFixedSwapFee: '0',
     consumeMarketOrderFee: consumeMarketOrderFee || '0',
@@ -187,11 +48,11 @@ export async function getOrderPriceAndFees(
     initializeData =
       !providerFees &&
       (await ProviderInstance.initialize(
-        asset?.id,
-        asset?.services[0].id,
+        asset.id,
+        service.id,
         0,
         accountId,
-        customProviderUrl || asset?.services[0].serviceEndpoint
+        customProviderUrl || service.serviceEndpoint
       ))
   } catch (error) {
     const message = getErrorMessage(error.message)
@@ -206,7 +67,7 @@ export async function getOrderPriceAndFees(
     ) {
       accountId !== ZERO_ADDRESS &&
         toast.error(
-          `Consumer address not found in allow list for service ${asset?.id}. Access has been denied.`
+          `Consumer address not found in allow list for service ${asset.id}. Access has been denied.`
         )
       return
     }
@@ -219,7 +80,7 @@ export async function getOrderPriceAndFees(
     ) {
       accountId !== ZERO_ADDRESS &&
         toast.error(
-          `Consumer address found in deny list for service ${asset?.id}. Access has been denied.`
+          `Consumer address found in deny list for service ${asset.id}. Access has been denied.`
         )
       return
     }
@@ -229,12 +90,8 @@ export async function getOrderPriceAndFees(
   orderPriceAndFee.providerFee = providerFees || initializeData.providerFee
 
   // fetch price and swap fees
-  if (asset?.accessDetails?.type === 'fixed') {
-    const fixed = await getFixedBuyPrice(
-      asset?.accessDetails,
-      asset?.chainId,
-      signer
-    )
+  if (accessDetails.type === 'fixed') {
+    const fixed = await getFixedBuyPrice(accessDetails, asset.chainId, signer)
     orderPriceAndFee.price = fixed.baseTokenAmount
     orderPriceAndFee.opcFee = fixed.oceanFeeAmount
     orderPriceAndFee.publisherMarketFixedSwapFee = fixed.marketFeeAmount
@@ -258,40 +115,80 @@ export async function getOrderPriceAndFees(
  * @returns {Promise<AccessDetails>}
  */
 export async function getAccessDetails(
-  chainId: number,
-  datatokenAddress: string,
-  timeout?: number,
-  account = ''
+  signer: Signer,
+  serviceStat: ServiceStat | undefined,
+  accountId: string
 ): Promise<AccessDetails> {
-  try {
-    const queryContext = getQueryContext(Number(chainId))
-    const tokenQueryResult: OperationResult<
-      TokenPriceQuery,
-      { datatokenId: string; account: string }
-    > = await fetchData(
-      tokenPriceQuery,
-      {
-        datatokenId: datatokenAddress.toLowerCase(),
-        account: account?.toLowerCase()
-      },
-      queryContext
-    )
-
-    const tokenPrice: TokenPrice = tokenQueryResult.data.token
-    const accessDetails = getAccessDetailsFromTokenPrice(tokenPrice, timeout)
-    return accessDetails
-  } catch (error) {
-    LoggerInstance.error('Error getting access details: ', error.message)
+  const accessDetails: AccessDetails = {
+    type: 'NOT_SUPPORTED',
+    price: '0',
+    templateId: 0,
+    addressOrId: '',
+    baseToken: {
+      address: '',
+      name: '',
+      symbol: '',
+      decimals: 0
+    },
+    datatoken: {
+      address: '',
+      name: '',
+      symbol: '',
+      decimals: 0
+    },
+    isOwned: false,
+    validOrderTx: '',
+    isPurchasable: false,
+    publisherMarketOrderFee: '0'
   }
+
+  if (serviceStat === undefined || serviceStat.prices.length === 0) {
+    return accessDetails
+  }
+
+  const tokenPrice = serviceStat.prices[0] // support only 1 price for now
+
+  if (tokenPrice.type === 'dispenser') {
+    accessDetails.type = 'free'
+    accessDetails.addressOrId = tokenPrice.contract
+    accessDetails.price = '0'
+  } else if (tokenPrice.type === 'fixedrate') {
+    accessDetails.type = 'fixed'
+    accessDetails.addressOrId = tokenPrice.exchangeId
+    accessDetails.price = tokenPrice.price
+    accessDetails.baseToken = {
+      address: tokenPrice.token.address,
+      name: tokenPrice.token.name,
+      symbol: tokenPrice.token.symbol,
+      decimals: tokenPrice.token.decimals
+    }
+  } else {
+    // unsupported type
+    return accessDetails
+  }
+
+  accessDetails.datatoken = {
+    address: serviceStat.datatokenAddress,
+    name: serviceStat.name,
+    symbol: serviceStat.symbol
+  }
+
+  // TODO
+  accessDetails.templateId = 1
+  accessDetails.isPurchasable = true
+  accessDetails.isOwned = false
+  accessDetails.validOrderTx = '' // should be possible to get from ocean-node - orders collection in typesense
+  accessDetails.publisherMarketOrderFee = '0'
+
+  return accessDetails
 }
 
-export function getAvailablePrice(asset: AssetExtended): AssetPrice {
-  const price: AssetPrice = asset?.stats?.price?.value
-    ? asset?.stats?.price
-    : {
-        value: Number(asset?.accessDetails?.price),
-        tokenSymbol: asset?.accessDetails?.baseToken?.symbol,
-        tokenAddress: asset?.accessDetails?.baseToken?.address
-      }
+export function getAvailablePrice(accessDetails: AccessDetails): AssetPrice {
+  const price: AssetPrice = {
+    value: Number(accessDetails.price),
+    tokenSymbol: accessDetails.baseToken?.symbol,
+    tokenAddress: accessDetails.baseToken?.address
+  }
+
   return price
 }

--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -14,7 +14,8 @@ import {
   UrlFile,
   AbiItem,
   UserCustomParameters,
-  getErrorMessage
+  getErrorMessage,
+  Service
 } from '@oceanprotocol/lib'
 // if customProviderUrl is set, we need to call provider using this custom endpoint
 import { customProviderUrl } from '../../app.config'
@@ -25,24 +26,26 @@ import { toast } from 'react-toastify'
 
 export async function initializeProviderForCompute(
   dataset: AssetExtended,
+  datasetService: Service,
+  datasetAccessDetails: AccessDetails,
   algorithm: AssetExtended,
   accountId: string,
   computeEnv: ComputeEnvironment = null
 ): Promise<ProviderComputeInitializeResults> {
   const computeAsset: ComputeAsset = {
     documentId: dataset.id,
-    serviceId: dataset.services[0].id,
-    transferTxId: dataset.accessDetails.validOrderTx
+    serviceId: datasetService.id,
+    transferTxId: datasetAccessDetails.validOrderTx
   }
   const computeAlgo: ComputeAlgorithm = {
     documentId: algorithm.id,
     serviceId: algorithm.services[0].id,
-    transferTxId: algorithm.accessDetails.validOrderTx
+    transferTxId: algorithm.accessDetails?.[0]?.validOrderTx
   }
 
   const validUntil = getValidUntilTime(
     computeEnv?.maxJobDuration,
-    dataset.services[0].timeout,
+    datasetService.timeout,
     algorithm.services[0].timeout
   )
 
@@ -52,7 +55,7 @@ export async function initializeProviderForCompute(
       computeAlgo,
       computeEnv?.id,
       validUntil,
-      customProviderUrl || dataset.services[0].serviceEndpoint,
+      customProviderUrl || datasetService.serviceEndpoint,
       accountId
     )
   } catch (error) {
@@ -230,6 +233,8 @@ export async function getFileInfo(
 export async function downloadFile(
   signer: Signer,
   asset: AssetExtended,
+  service: Service,
+  accessDetails: AccessDetails,
   accountId: string,
   validOrderTx?: string,
   userCustomParameters?: UserCustomParameters
@@ -238,10 +243,10 @@ export async function downloadFile(
   try {
     downloadUrl = await ProviderInstance.getDownloadUrl(
       asset.id,
-      asset.services[0].id,
+      service.id,
       0,
-      validOrderTx || asset.accessDetails.validOrderTx,
-      customProviderUrl || asset.services[0].serviceEndpoint,
+      validOrderTx || accessDetails.validOrderTx,
+      customProviderUrl || service.serviceEndpoint,
       signer,
       userCustomParameters
     )

--- a/src/components/@shared/AssetTeaser/index.tsx
+++ b/src/components/@shared/AssetTeaser/index.tsx
@@ -10,7 +10,6 @@ import styles from './index.module.css'
 import { getServiceByName } from '@utils/ddo'
 import { useUserPreferences } from '@context/UserPreferences'
 import { formatNumber } from '@utils/numbers'
-import { AssetPrice } from '@oceanprotocol/lib'
 
 export declare type AssetTeaserProps = {
   asset: AssetExtended
@@ -28,12 +27,12 @@ export default function AssetTeaser({
   const { datatokens } = asset
   const isCompute = Boolean(getServiceByName(asset, 'compute'))
   const accessType = isCompute ? 'compute' : 'access'
-  const { owner } = asset.nft
-  const { orders, allocated, price } = asset.stats
+  const owner = asset.nft?.owner
+  const { orders, allocated, price } = asset.stats || {}
   const isUnsupportedPricing =
     !asset.services.length ||
-    price.value === undefined ||
-    asset?.accessDetails?.type === 'NOT_SUPPORTED'
+    price?.value === undefined ||
+    asset?.accessDetails[0].type === 'NOT_SUPPORTED'
   const { locale } = useUserPreferences()
 
   return (

--- a/src/components/Asset/AssetActions/Compute/AlgorithmDatasetsListForCompute.tsx
+++ b/src/components/Asset/AssetActions/Compute/AlgorithmDatasetsListForCompute.tsx
@@ -4,15 +4,17 @@ import { getAlgorithmDatasetsForCompute } from '@utils/aquarius'
 import { AssetSelectionAsset } from '@shared/FormInput/InputElement/AssetSelection'
 import AssetComputeList from './AssetComputeList'
 import { useCancelToken } from '@hooks/useCancelToken'
-import { getServiceByName } from '@utils/ddo'
 import { useAccount } from 'wagmi'
+import { Service } from '@oceanprotocol/lib'
 
 export default function AlgorithmDatasetsListForCompute({
   asset,
-  algorithmDid
+  service,
+  accessDetails
 }: {
   asset: AssetExtended
-  algorithmDid: string
+  service: Service
+  accessDetails: AccessDetails
 }): ReactElement {
   const { address: accountId } = useAccount()
   const newCancelToken = useCancelToken()
@@ -20,25 +22,20 @@ export default function AlgorithmDatasetsListForCompute({
     useState<AssetSelectionAsset[]>()
 
   useEffect(() => {
-    if (!asset || !asset?.accessDetails?.type) return
+    if (!accessDetails.type) return
 
     async function getDatasetsAllowedForCompute() {
-      const isCompute = Boolean(getServiceByName(asset, 'compute'))
-      const datasetComputeService = getServiceByName(
-        asset,
-        isCompute ? 'compute' : 'access'
-      )
       const datasets = await getAlgorithmDatasetsForCompute(
-        algorithmDid,
-        datasetComputeService?.serviceEndpoint,
+        asset.id,
+        service.serviceEndpoint,
         accountId,
-        asset?.chainId,
+        asset.chainId,
         newCancelToken()
       )
       setDatasetsForCompute(datasets)
     }
     asset.metadata.type === 'algorithm' && getDatasetsAllowedForCompute()
-  }, [accountId, asset, algorithmDid, newCancelToken])
+  }, [accessDetails, accountId, asset, newCancelToken, service])
 
   return (
     <div className={styles.datasetsContainer}>

--- a/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
@@ -8,7 +8,12 @@ import ButtonBuy from '../ButtonBuy'
 import PriceOutput from './PriceOutput'
 import { useAsset } from '@context/Asset'
 import content from '../../../../../content/pages/startComputeDataset.json'
-import { Asset, ComputeEnvironment, ZERO_ADDRESS } from '@oceanprotocol/lib'
+import {
+  Asset,
+  ComputeEnvironment,
+  Service,
+  ZERO_ADDRESS
+} from '@oceanprotocol/lib'
 import { getAccessDetails } from '@utils/accessDetailsAndPricing'
 import { getTokenBalanceFromSymbol } from '@utils/wallet'
 import { MAX_DECIMALS } from '@utils/constants'
@@ -20,16 +25,18 @@ import ConsumerParameters from '../ConsumerParameters'
 import { ComputeDatasetForm } from './_constants'
 
 export default function FormStartCompute({
+  asset,
+  service,
+  accessDetails,
   algorithms,
   ddoListAlgorithms,
   selectedAlgorithmAsset,
-  setSelectedAlgorithm,
+  setSelectedAlgorithmAsset,
   isLoading,
   isComputeButtonDisabled,
   hasPreviousOrder,
   hasDatatoken,
   dtBalance,
-  assetType,
   assetTimeout,
   hasPreviousOrderSelectedComputeAsset,
   hasDatatokenSelectedComputeAsset,
@@ -53,16 +60,18 @@ export default function FormStartCompute({
   validUntil,
   retry
 }: {
+  asset: AssetExtended
+  service: Service
+  accessDetails: AccessDetails
   algorithms: AssetSelectionAsset[]
   ddoListAlgorithms: Asset[]
   selectedAlgorithmAsset: AssetExtended
-  setSelectedAlgorithm: React.Dispatch<React.SetStateAction<AssetExtended>>
+  setSelectedAlgorithmAsset: React.Dispatch<React.SetStateAction<AssetExtended>>
   isLoading: boolean
   isComputeButtonDisabled: boolean
   hasPreviousOrder: boolean
   hasDatatoken: boolean
   dtBalance: string
-  assetType: string
   assetTimeout: string
   hasPreviousOrderSelectedComputeAsset?: boolean
   hasDatatokenSelectedComputeAsset?: boolean
@@ -96,13 +105,13 @@ export default function FormStartCompute({
     setFieldValue,
     values
   }: FormikContextType<ComputeDatasetForm> = useFormikContext()
-  const { asset, isAssetNetwork } = useAsset()
+  const { isAssetNetwork } = useAsset() // TODO - is this needed?
 
   const [datasetOrderPrice, setDatasetOrderPrice] = useState(
-    asset?.accessDetails?.price
+    accessDetails.price
   )
   const [algoOrderPrice, setAlgoOrderPrice] = useState(
-    selectedAlgorithmAsset?.accessDetails?.price
+    selectedAlgorithmAsset?.accessDetails?.[0]?.price
   )
   const [totalPrices, setTotalPrices] = useState([])
   const [isBalanceSufficient, setIsBalanceSufficient] = useState<boolean>(true)
@@ -143,20 +152,26 @@ export default function FormStartCompute({
 
     async function fetchAlgorithmAssetExtended() {
       const algorithmAsset = getAlgorithmAsset(values.algorithm)
-      const accessDetails = await getAccessDetails(
-        algorithmAsset.chainId,
-        algorithmAsset.services[0].datatokenAddress,
-        algorithmAsset.services[0].timeout,
-        accountId || ZERO_ADDRESS // if user is not connected, use ZERO_ADDRESS as accountId
+
+      const algoAccessDetails = await Promise.all(
+        algorithmAsset.services.map((service) =>
+          getAccessDetails(
+            algorithmAsset.chainId,
+            service.datatokenAddress,
+            service.timeout,
+            accountId || ZERO_ADDRESS // if user is not connected, use ZERO_ADDRESS as accountId
+          )
+        )
       )
+
       const extendedAlgoAsset: AssetExtended = {
         ...algorithmAsset,
-        accessDetails
+        accessDetails: algoAccessDetails
       }
-      setSelectedAlgorithm(extendedAlgoAsset)
+      setSelectedAlgorithmAsset(extendedAlgoAsset)
     }
     fetchAlgorithmAssetExtended()
-  }, [values.algorithm, accountId, isConsumable])
+  }, [values.algorithm, accountId, isConsumable, setSelectedAlgorithmAsset])
 
   useEffect(() => {
     if (!values.computeEnv) return
@@ -169,14 +184,13 @@ export default function FormStartCompute({
   // Set price for calculation output
   //
   useEffect(() => {
-    if (!asset?.accessDetails || !selectedAlgorithmAsset?.accessDetails) return
+    if (!asset?.accessDetails || !selectedAlgorithmAsset?.accessDetails?.length)
+      return
 
-    setDatasetOrderPrice(
-      datasetOrderPriceAndFees?.price || asset.accessDetails.price
-    )
+    setDatasetOrderPrice(datasetOrderPriceAndFees?.price || accessDetails.price)
     setAlgoOrderPrice(
       algoOrderPriceAndFees?.price ||
-        selectedAlgorithmAsset?.accessDetails.price
+        selectedAlgorithmAsset?.accessDetails?.[0]?.price
     )
     const totalPrices: totalPriceMap[] = []
     const priceDataset =
@@ -255,7 +269,7 @@ export default function FormStartCompute({
     algoOrderPriceAndFees,
     providerFeeAmount,
     isAssetNetwork,
-    selectedAlgorithmAsset?.accessDetails,
+    selectedAlgorithmAsset,
     datasetOrderPrice,
     algoOrderPrice,
     algorithmSymbol,
@@ -305,7 +319,7 @@ export default function FormStartCompute({
       ))}
       {asset && selectedAlgorithmAsset && (
         <ConsumerParameters
-          asset={asset}
+          service={service}
           selectedAlgorithmAsset={selectedAlgorithmAsset}
           isLoading={isLoading}
         />
@@ -319,7 +333,7 @@ export default function FormStartCompute({
         hasDatatoken={hasDatatoken}
         selectedComputeAssetTimeout={selectedComputeAssetTimeout}
         hasDatatokenSelectedComputeAsset={hasDatatokenSelectedComputeAsset}
-        algorithmConsumeDetails={selectedAlgorithmAsset?.accessDetails}
+        algorithmConsumeDetails={selectedAlgorithmAsset?.accessDetails?.[0]}
         symbol={datasetSymbol}
         algorithmSymbol={algorithmSymbol}
         datasetOrderPrice={datasetOrderPrice}
@@ -337,16 +351,16 @@ export default function FormStartCompute({
           !isValid ||
           !isBalanceSufficient ||
           !isAssetNetwork ||
-          !selectedAlgorithmAsset?.accessDetails?.isPurchasable ||
+          !selectedAlgorithmAsset?.accessDetails?.[0]?.isPurchasable ||
           !isAccountIdWhitelisted
         }
         hasPreviousOrder={hasPreviousOrder}
         hasDatatoken={hasDatatoken}
-        btSymbol={asset?.accessDetails?.baseToken?.symbol}
-        dtSymbol={asset?.datatokens[0]?.symbol}
+        btSymbol={accessDetails.baseToken?.symbol}
+        dtSymbol={accessDetails.datatoken?.symbol}
         dtBalance={dtBalance}
         assetTimeout={assetTimeout}
-        assetType={assetType}
+        assetType={asset.metadata.type}
         hasPreviousOrderSelectedComputeAsset={
           hasPreviousOrderSelectedComputeAsset
         }
@@ -357,13 +371,13 @@ export default function FormStartCompute({
         stepText={stepText}
         isLoading={isLoading}
         type="submit"
-        priceType={asset?.accessDetails?.type}
-        algorithmPriceType={selectedAlgorithmAsset?.accessDetails?.type}
+        priceType={accessDetails.type}
+        algorithmPriceType={selectedAlgorithmAsset?.accessDetails?.[0]?.type}
         isBalanceSufficient={isBalanceSufficient}
         isConsumable={isConsumable}
         consumableFeedback={consumableFeedback}
         isAlgorithmConsumable={
-          selectedAlgorithmAsset?.accessDetails?.isPurchasable
+          selectedAlgorithmAsset?.accessDetails?.[0]?.isPurchasable
         }
         isSupportedOceanNetwork={isSupportedOceanNetwork}
         hasProviderFee={providerFeeAmount && providerFeeAmount !== '0'}

--- a/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
@@ -8,12 +8,7 @@ import ButtonBuy from '../ButtonBuy'
 import PriceOutput from './PriceOutput'
 import { useAsset } from '@context/Asset'
 import content from '../../../../../content/pages/startComputeDataset.json'
-import {
-  Asset,
-  ComputeEnvironment,
-  Service,
-  ZERO_ADDRESS
-} from '@oceanprotocol/lib'
+import { Asset, ComputeEnvironment, Service } from '@oceanprotocol/lib'
 import { getAccessDetails } from '@utils/accessDetailsAndPricing'
 import { getTokenBalanceFromSymbol } from '@utils/wallet'
 import { MAX_DECIMALS } from '@utils/constants'
@@ -151,15 +146,15 @@ export default function FormStartCompute({
     if (!values.algorithm || !isConsumable) return
 
     async function fetchAlgorithmAssetExtended() {
-      const algorithmAsset = getAlgorithmAsset(values.algorithm)
+      // TODO test this type override
+      const algorithmAsset: AssetExtended = getAlgorithmAsset(values.algorithm)
 
       const algoAccessDetails = await Promise.all(
         algorithmAsset.services.map((service) =>
           getAccessDetails(
-            algorithmAsset.chainId,
-            service.datatokenAddress,
-            service.timeout,
-            accountId || ZERO_ADDRESS // if user is not connected, use ZERO_ADDRESS as accountId
+            algorithmAsset.offchain?.stats.services.find(
+              (s) => s.serviceId === service.id
+            )
           )
         )
       )

--- a/src/components/Asset/AssetActions/Compute/_constants.ts
+++ b/src/components/Asset/AssetActions/Compute/_constants.ts
@@ -1,6 +1,7 @@
 import {
   ComputeEnvironment,
   ConsumerParameter,
+  Service,
   UserCustomParameters
 } from '@oceanprotocol/lib'
 import * as Yup from 'yup'
@@ -43,7 +44,7 @@ export function getComputeValidationSchema(
 }
 
 export function getInitialValues(
-  asset?: AssetExtended,
+  service: Service,
   selectedAlgorithmAsset?: AssetExtended,
   selectedComputeEnv?: ComputeEnvironment,
   termsAndConditions?: boolean
@@ -51,7 +52,7 @@ export function getInitialValues(
   return {
     algorithm: selectedAlgorithmAsset?.id,
     computeEnv: selectedComputeEnv?.id,
-    dataServiceParams: getDefaultValues(asset?.services[0].consumerParameters),
+    dataServiceParams: getDefaultValues(service.consumerParameters),
     algoServiceParams: getDefaultValues(
       selectedAlgorithmAsset?.services[0].consumerParameters
     ),

--- a/src/components/Asset/AssetActions/ConsumerParameters/index.tsx
+++ b/src/components/Asset/AssetActions/ConsumerParameters/index.tsx
@@ -2,7 +2,11 @@ import { ReactElement, useCallback, useEffect, useState } from 'react'
 import FormConsumerParameters from './FormConsumerParameters'
 import styles from './index.module.css'
 import Tabs, { TabsItem } from '@shared/atoms/Tabs'
-import { ConsumerParameter, UserCustomParameters } from '@oceanprotocol/lib'
+import {
+  ConsumerParameter,
+  Service,
+  UserCustomParameters
+} from '@oceanprotocol/lib'
 
 export function parseConsumerParameterValues(
   formValues?: UserCustomParameters,
@@ -33,11 +37,11 @@ export function parseConsumerParameterValues(
 }
 
 export default function ConsumerParameters({
-  asset,
+  service,
   selectedAlgorithmAsset,
   isLoading
 }: {
-  asset: AssetExtended
+  service: Service
   selectedAlgorithmAsset?: AssetExtended
   isLoading?: boolean
 }): ReactElement {
@@ -46,18 +50,19 @@ export default function ConsumerParameters({
 
   const updateTabs = useCallback(() => {
     const tabs = []
-    if (asset?.services[0]?.consumerParameters?.length > 0) {
+    if (service.consumerParameters?.length > 0) {
       tabs.push({
         title: 'Data Service',
         content: (
           <FormConsumerParameters
             name="dataServiceParams"
-            parameters={asset.services[0].consumerParameters}
+            parameters={service.consumerParameters}
             disabled={isLoading}
           />
         )
       })
     }
+    // TODO -
     if (selectedAlgorithmAsset?.services[0]?.consumerParameters?.length > 0) {
       tabs.push({
         title: 'Algo Service',
@@ -71,8 +76,7 @@ export default function ConsumerParameters({
       })
     }
     if (
-      selectedAlgorithmAsset?.metadata?.algorithm?.consumerParameters?.length >
-      0
+      selectedAlgorithmAsset?.metadata?.algorithm?.consumerParameters?.length
     ) {
       tabs.push({
         title: 'Algo Params',
@@ -89,7 +93,7 @@ export default function ConsumerParameters({
     }
 
     return tabs
-  }, [asset, selectedAlgorithmAsset, isLoading])
+  }, [selectedAlgorithmAsset, service, isLoading])
 
   useEffect(() => {
     setTabs(updateTabs())

--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -10,6 +10,7 @@ import {
   AssetPrice,
   FileInfo,
   LoggerInstance,
+  Service,
   UserCustomParameters,
   ZERO_ADDRESS
 } from '@oceanprotocol/lib'
@@ -42,6 +43,9 @@ export default function Download({
   accountId,
   signer,
   asset,
+  service,
+  accessDetails,
+  serviceIndex,
   file,
   isBalanceSufficient,
   dtBalance,
@@ -52,6 +56,9 @@ export default function Download({
   accountId: string
   signer: Signer
   asset: AssetExtended
+  service: Service
+  accessDetails: AccessDetails
+  serviceIndex: number
   file: FileInfo
   isBalanceSufficient: boolean
   dtBalance: string
@@ -77,29 +84,26 @@ export default function Download({
     useState<OrderPriceAndFees>()
   const [retry, setRetry] = useState<boolean>(false)
 
-  const price: AssetPrice = getAvailablePrice(asset)
+  const price: AssetPrice = getAvailablePrice(accessDetails)
   const isUnsupportedPricing =
-    !asset?.accessDetails ||
-    !asset.services.length ||
-    asset?.accessDetails?.type === 'NOT_SUPPORTED' ||
-    (asset?.accessDetails?.type === 'fixed' &&
-      !asset?.accessDetails?.baseToken?.symbol)
+    accessDetails.type === 'NOT_SUPPORTED' ||
+    (accessDetails.type === 'fixed' && !accessDetails.baseToken?.symbol)
 
   useEffect(() => {
-    Number(asset?.nft.state) === 4 && setIsOrderDisabled(true)
-  }, [asset?.nft.state])
+    Number(asset.nft.state) === 4 && setIsOrderDisabled(true)
+  }, [asset.nft.state])
 
   useEffect(() => {
     if (isUnsupportedPricing) return
 
-    setIsOwned(asset?.accessDetails?.isOwned || false)
-    setValidOrderTx(asset?.accessDetails?.validOrderTx || '')
+    setIsOwned(accessDetails.isOwned || false)
+    setValidOrderTx(accessDetails.validOrderTx || '')
 
     // get full price and fees
     async function init() {
       if (
-        asset.accessDetails.addressOrId === ZERO_ADDRESS ||
-        asset.accessDetails.type === 'free'
+        accessDetails.addressOrId === ZERO_ADDRESS ||
+        accessDetails.type === 'free'
       )
         return
 
@@ -108,6 +112,8 @@ export default function Download({
 
         const _orderPriceAndFees = await getOrderPriceAndFees(
           asset,
+          service,
+          accessDetails,
           accountId || ZERO_ADDRESS
         )
         setOrderPriceAndFees(_orderPriceAndFees)
@@ -118,15 +124,21 @@ export default function Download({
       }
     }
 
-    init()
+    if (!orderPriceAndFees) init()
 
     /**
      * we listen to the assets' changes to get the most updated price
      * based on the asset and the poolData's information.
      * Not adding isLoading and getOpcFeeForToken because we set these here. It is a compromise
      */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asset, getOpcFeeForToken, isUnsupportedPricing])
+  }, [
+    accessDetails,
+    accountId,
+    asset,
+    isUnsupportedPricing,
+    orderPriceAndFees,
+    service
+  ])
 
   useEffect(() => {
     setHasDatatoken(Number(dtBalance) >= 1)
@@ -134,7 +146,7 @@ export default function Download({
 
   useEffect(() => {
     if (
-      (asset?.accessDetails?.type === 'fixed' && !orderPriceAndFees) ||
+      (accessDetails.type === 'fixed' && !orderPriceAndFees) ||
       !isMounted ||
       !accountId ||
       isUnsupportedPricing
@@ -150,17 +162,15 @@ export default function Download({
      * - if user is not whitelisted or blacklisted
      */
     const isDisabled =
-      !asset?.accessDetails.isPurchasable ||
+      !accessDetails.isPurchasable ||
       !isAssetNetwork ||
       ((!isBalanceSufficient || !isAssetNetwork) &&
         !isOwned &&
         !hasDatatoken) ||
       !isAccountIdWhitelisted
-
     setIsDisabled(isDisabled)
   }, [
     isMounted,
-    asset,
     isBalanceSufficient,
     isAssetNetwork,
     hasDatatoken,
@@ -168,7 +178,8 @@ export default function Download({
     isOwned,
     isUnsupportedPricing,
     orderPriceAndFees,
-    isAccountIdWhitelisted
+    isAccountIdWhitelisted,
+    accessDetails
   ])
 
   async function handleOrderOrDownload(dataParams?: UserCustomParameters) {
@@ -178,22 +189,32 @@ export default function Download({
       if (isOwned) {
         setStatusText(
           getOrderFeedback(
-            asset.accessDetails.baseToken?.symbol,
-            asset.accessDetails.datatoken?.symbol
+            accessDetails.baseToken?.symbol,
+            accessDetails.datatoken?.symbol
           )[3]
         )
 
-        await downloadFile(signer, asset, accountId, validOrderTx, dataParams)
+        await downloadFile(
+          signer,
+          asset,
+          service,
+          accessDetails,
+          accountId,
+          validOrderTx,
+          dataParams
+        )
       } else {
         setStatusText(
           getOrderFeedback(
-            asset.accessDetails.baseToken?.symbol,
-            asset.accessDetails.datatoken?.symbol
-          )[asset.accessDetails.type === 'fixed' ? 2 : 1]
+            accessDetails.baseToken?.symbol,
+            accessDetails.datatoken?.symbol
+          )[accessDetails.type === 'fixed' ? 2 : 1]
         )
         const orderTx = await order(
           signer,
           asset,
+          service,
+          accessDetails,
           orderPriceAndFees,
           accountId,
           hasDatatoken
@@ -222,16 +243,16 @@ export default function Download({
       disabled={isDisabled || !isValid}
       hasPreviousOrder={isOwned}
       hasDatatoken={hasDatatoken}
-      btSymbol={asset?.accessDetails?.baseToken?.symbol}
-      dtSymbol={asset?.datatokens[0]?.symbol}
+      btSymbol={accessDetails.baseToken?.symbol}
+      dtSymbol={asset.datatokens[serviceIndex]?.symbol} // TODO - check datatokens
       dtBalance={dtBalance}
       type="submit"
-      assetTimeout={secondsToString(asset?.services?.[0]?.timeout)}
-      assetType={asset?.metadata?.type}
+      assetTimeout={secondsToString(service.timeout)}
+      assetType={asset.metadata?.type}
       stepText={statusText}
       isLoading={isLoading}
-      priceType={asset.accessDetails?.type}
-      isConsumable={asset.accessDetails?.isPurchasable}
+      priceType={accessDetails.type}
+      isConsumable={accessDetails.isPurchasable}
       isBalanceSufficient={isBalanceSufficient}
       consumableFeedback={consumableFeedback}
       retry={retry}
@@ -291,19 +312,15 @@ export default function Download({
   return (
     <Formik
       initialValues={{
-        dataServiceParams: getDefaultValues(
-          asset?.services[0].consumerParameters
-        ),
+        dataServiceParams: getDefaultValues(service.consumerParameters),
         termsAndConditions: false
       }}
       validateOnMount
-      validationSchema={getDownloadValidationSchema(
-        asset?.services[0].consumerParameters
-      )}
+      validationSchema={getDownloadValidationSchema(service.consumerParameters)}
       onSubmit={async (values) => {
         const dataServiceParams = parseConsumerParameterValues(
           values?.dataServiceParams,
-          asset.services[0].consumerParameters
+          service.consumerParameters
         )
 
         await handleOrderOrDownload(dataServiceParams)
@@ -323,9 +340,8 @@ export default function Download({
             <AssetAction asset={asset} />
           </div>
           <div className={styles.consumerParameters}>
-            {asset && (
-              <ConsumerParameters asset={asset} isLoading={isLoading} />
-            )}
+            {/* TODO - */}
+            <ConsumerParameters service={service} isLoading={isLoading} />
           </div>
           {isOwned && (
             <div className={styles.confettiContainer}>
@@ -334,10 +350,11 @@ export default function Download({
               />
             </div>
           )}
-          {asset?.metadata?.type === 'algorithm' && (
+          {asset.metadata?.type === 'algorithm' && (
             <AlgorithmDatasetsListForCompute
-              algorithmDid={asset.id}
               asset={asset}
+              service={service}
+              accessDetails={accessDetails}
             />
           )}
           {accountId && (

--- a/src/components/Asset/AssetActions/index.tsx
+++ b/src/components/Asset/AssetActions/index.tsx
@@ -145,7 +145,7 @@ export default function AssetActions({
       }
     }
     init()
-  }, [web3Provider, accountId, asset, isAssetNetwork, service.datatokenAddress])
+  }, [web3Provider, accountId, isAssetNetwork, service.datatokenAddress])
 
   // Check user balance against price
   useEffect(() => {

--- a/src/components/Asset/AssetActions/index.tsx
+++ b/src/components/Asset/AssetActions/index.tsx
@@ -1,7 +1,12 @@
 import { ReactElement, useState, useEffect } from 'react'
 import Compute from './Compute'
 import Download from './Download'
-import { FileInfo, LoggerInstance, Datatoken } from '@oceanprotocol/lib'
+import {
+  FileInfo,
+  LoggerInstance,
+  Datatoken,
+  Service
+} from '@oceanprotocol/lib'
 import { compareAsBN } from '@utils/numbers'
 import { useAsset } from '@context/Asset'
 import { getFileDidInfo, getFileInfo } from '@utils/provider'
@@ -16,11 +21,20 @@ import AssetStats from './AssetStats'
 import { isAddressWhitelisted } from '@utils/ddo'
 import { useAccount, useProvider, useNetwork, useSigner } from 'wagmi'
 import useBalance from '@hooks/useBalance'
+import Button from '@components/@shared/atoms/Button'
 
 export default function AssetActions({
-  asset
+  asset,
+  service,
+  accessDetails,
+  serviceIndex,
+  handleBack
 }: {
   asset: AssetExtended
+  service: Service
+  accessDetails: AccessDetails
+  serviceIndex: number
+  handleBack: () => void
 }): ReactElement {
   const { address: accountId } = useAccount()
   const { data: signer } = useSigner()
@@ -44,37 +58,35 @@ export default function AssetActions({
   const [isAccountIdWhitelisted, setIsAccountIdWhitelisted] =
     useState<boolean>()
 
-  const isCompute = Boolean(
-    asset?.services.filter((service) => service.type === 'compute')[0]
-  )
+  const isCompute = service.type === 'compute'
 
   // Get and set file info
   useEffect(() => {
-    const oceanConfig = getOceanConfig(asset?.chainId)
+    const oceanConfig = getOceanConfig(asset.chainId)
     if (!oceanConfig) return
 
     async function initFileInfo() {
       setFileIsLoading(true)
       const providerUrl =
-        formikState?.values?.services[0].providerUrl.url ||
-        asset?.services[0]?.serviceEndpoint
+        formikState?.values?.services[serviceIndex].providerUrl.url ||
+        service.serviceEndpoint
 
       const storageType = formikState?.values?.services
-        ? formikState?.values?.services[0].files[0].type
+        ? formikState?.values?.services[serviceIndex].files[0].type
         : null
 
       // TODO: replace 'any' with correct typing
-      const file = formikState?.values?.services[0].files[0] as any
+      const file = formikState?.values?.services[serviceIndex].files[0] as any
       const query = file?.query || undefined
       const abi = file?.abi || undefined
       const headers = file?.headers || undefined
       const method = file?.method || undefined
 
       try {
-        const fileInfoResponse = formikState?.values?.services?.[0].files?.[0]
-          .url
+        const fileInfoResponse = formikState?.values?.services?.[serviceIndex]
+          .files?.[0].url
           ? await getFileInfo(
-              formikState?.values?.services?.[0].files?.[0].url,
+              formikState?.values?.services?.[serviceIndex].files?.[0].url,
               providerUrl,
               storageType,
               query,
@@ -83,7 +95,7 @@ export default function AssetActions({
               chain?.id,
               method
             )
-          : await getFileDidInfo(asset?.id, asset?.services[0]?.id, providerUrl)
+          : await getFileDidInfo(asset.id, service.id, providerUrl)
 
         fileInfoResponse && setFileMetadata(fileInfoResponse[0])
 
@@ -105,7 +117,16 @@ export default function AssetActions({
       }
     }
     initFileInfo()
-  }, [asset, isMounted, newCancelToken, formikState?.values?.services])
+  }, [
+    asset,
+    isMounted,
+    newCancelToken,
+    formikState?.values?.services,
+    serviceIndex,
+    chain?.id,
+    service.serviceEndpoint,
+    service.id
+  ])
 
   // Get and set user DT balance
   useEffect(() => {
@@ -115,7 +136,7 @@ export default function AssetActions({
       try {
         const datatokenInstance = new Datatoken(web3Provider as any)
         const dtBalance = await datatokenInstance.balance(
-          asset.services[0].datatokenAddress,
+          service.datatokenAddress,
           accountId
         )
         setDtBalance(dtBalance)
@@ -124,14 +145,14 @@ export default function AssetActions({
       }
     }
     init()
-  }, [web3Provider, accountId, asset, isAssetNetwork])
+  }, [web3Provider, accountId, asset, isAssetNetwork, service.datatokenAddress])
 
   // Check user balance against price
   useEffect(() => {
-    if (asset?.accessDetails?.type === 'free') setIsBalanceSufficient(true)
+    if (accessDetails.type === 'free') setIsBalanceSufficient(true)
     if (
-      !asset?.accessDetails?.price ||
-      !asset?.accessDetails?.baseToken?.symbol ||
+      !accessDetails.price ||
+      !accessDetails.baseToken?.symbol ||
       !accountId ||
       !balance ||
       !dtBalance
@@ -140,18 +161,18 @@ export default function AssetActions({
 
     const baseTokenBalance = getTokenBalanceFromSymbol(
       balance,
-      asset?.accessDetails?.baseToken?.symbol
+      accessDetails.baseToken?.symbol
     )
 
     setIsBalanceSufficient(
-      compareAsBN(baseTokenBalance, `${asset?.accessDetails.price}`) ||
+      compareAsBN(baseTokenBalance, `${accessDetails.price}`) ||
         Number(dtBalance) >= 1
     )
 
     return () => {
       setIsBalanceSufficient(false)
     }
-  }, [balance, accountId, asset?.accessDetails, dtBalance])
+  }, [balance, accountId, dtBalance, accessDetails])
 
   // check for if user is whitelisted or blacklisted
   useEffect(() => {
@@ -161,30 +182,40 @@ export default function AssetActions({
   }, [accountId, asset])
 
   return (
-    <div className={styles.actions}>
-      {isCompute ? (
-        <Compute
-          accountId={accountId}
-          signer={signer}
-          asset={asset}
-          dtBalance={dtBalance}
-          isAccountIdWhitelisted={isAccountIdWhitelisted}
-          file={fileMetadata}
-          fileIsLoading={fileIsLoading}
-        />
-      ) : (
-        <Download
-          accountId={accountId}
-          signer={signer}
-          asset={asset}
-          dtBalance={dtBalance}
-          isBalanceSufficient={isBalanceSufficient}
-          isAccountIdWhitelisted={isAccountIdWhitelisted}
-          file={fileMetadata}
-          fileIsLoading={fileIsLoading}
-        />
-      )}
-      <AssetStats />
-    </div>
+    <>
+      <Button style="text" size="small" onClick={handleBack}>
+        Back
+      </Button>
+      <div className={styles.actions}>
+        {isCompute ? (
+          <Compute
+            accountId={accountId}
+            signer={signer}
+            asset={asset}
+            service={service}
+            accessDetails={accessDetails}
+            dtBalance={dtBalance}
+            isAccountIdWhitelisted={isAccountIdWhitelisted}
+            file={fileMetadata}
+            fileIsLoading={fileIsLoading}
+          />
+        ) : (
+          <Download
+            accountId={accountId}
+            signer={signer}
+            asset={asset}
+            service={service}
+            accessDetails={accessDetails}
+            serviceIndex={serviceIndex}
+            dtBalance={dtBalance}
+            isBalanceSufficient={isBalanceSufficient}
+            isAccountIdWhitelisted={isAccountIdWhitelisted}
+            file={fileMetadata}
+            fileIsLoading={fileIsLoading}
+          />
+        )}
+        <AssetStats />
+      </div>
+    </>
   )
 }

--- a/src/components/Asset/AssetContent/ServiceCard.module.css
+++ b/src/components/Asset/AssetContent/ServiceCard.module.css
@@ -1,0 +1,20 @@
+.service {
+  border-radius: var(--box-template-border-radius);
+  border: var(--box-template-border-size) solid var(--box-template-border-color);
+  cursor: pointer;
+  padding: calc(var(--spacer) * 0.5) var(--spacer);
+  margin: var(--spacer) 0;
+}
+
+.service:hover {
+  box-shadow: var(--box-template-box-shadow);
+}
+
+.title {
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-small);
+  margin-bottom: calc(var(--spacer) / 4);
+  color: var(--font-color-heading);
+  text-transform: uppercase;
+}

--- a/src/components/Asset/AssetContent/ServiceCard.tsx
+++ b/src/components/Asset/AssetContent/ServiceCard.tsx
@@ -1,0 +1,31 @@
+import { ReactElement } from 'react'
+import styles from './ServiceCard.module.css'
+import { Service } from '@oceanprotocol/lib'
+
+export default function ServiceCard({
+  service,
+  accessDetails,
+  onClick
+}: {
+  service: Service
+  accessDetails: AccessDetails
+  onClick: () => void
+}): ReactElement {
+  return (
+    <div onClick={onClick} className={styles.service}>
+      <span className={styles.title}>Name: </span>
+      {service.name || 'Unknown'}
+      <br />
+      <span className={styles.title}>Description: </span>
+      <span>{service.description}</span>
+      <br />
+      <span className={styles.title}>Type: </span>
+      {service.type}
+      <br />
+      <span className={styles.title}>Price: </span>
+      {accessDetails.type === 'fixed'
+        ? `${accessDetails.price} ${accessDetails.baseToken.symbol}`
+        : '0'}
+    </div>
+  )
+}

--- a/src/components/Asset/AssetContent/index.tsx
+++ b/src/components/Asset/AssetContent/index.tsx
@@ -29,7 +29,7 @@ export default function AssetContent({
   const { allowExternalContent, debug } = useUserPreferences()
   const [receipts, setReceipts] = useState([])
   const [nftPublisher, setNftPublisher] = useState<string>()
-  const [selectedService, setSelectedService] = useState<number>(-1)
+  const [selectedService, setSelectedService] = useState<number | undefined>()
 
   useEffect(() => {
     if (!receipts.length) return
@@ -78,7 +78,7 @@ export default function AssetContent({
             <p>Loading access details...</p>
           ) : (
             <>
-              {selectedService === -1 ? (
+              {selectedService === undefined ? (
                 <>
                   <h3>Available services:</h3>
                   {asset.services.map((service, index) => (
@@ -96,7 +96,7 @@ export default function AssetContent({
                   service={asset.services[selectedService]}
                   accessDetails={asset.accessDetails[selectedService]}
                   serviceIndex={selectedService}
-                  handleBack={() => setSelectedService(-1)}
+                  handleBack={() => setSelectedService(undefined)}
                 />
               )}
             </>

--- a/src/components/Asset/AssetContent/index.tsx
+++ b/src/components/Asset/AssetContent/index.tsx
@@ -17,6 +17,7 @@ import Button from '@shared/atoms/Button'
 import RelatedAssets from '../RelatedAssets'
 import Web3Feedback from '@components/@shared/Web3Feedback'
 import { useAccount } from 'wagmi'
+import ServiceCard from './ServiceCard'
 
 export default function AssetContent({
   asset
@@ -28,6 +29,7 @@ export default function AssetContent({
   const { allowExternalContent, debug } = useUserPreferences()
   const [receipts, setReceipts] = useState([])
   const [nftPublisher, setNftPublisher] = useState<string>()
+  const [selectedService, setSelectedService] = useState<number>(-1)
 
   useEffect(() => {
     if (!receipts.length) return
@@ -40,16 +42,14 @@ export default function AssetContent({
   return (
     <>
       <div className={styles.networkWrap}>
-        <NetworkName networkId={asset?.chainId} className={styles.network} />
+        <NetworkName networkId={asset.chainId} className={styles.network} />
       </div>
 
       <article className={styles.grid}>
         <div>
           <div className={styles.content}>
             <MetaMain asset={asset} nftPublisher={nftPublisher} />
-            {asset?.accessDetails?.datatoken !== null && (
-              <Bookmark did={asset?.id} />
-            )}
+            <Bookmark did={asset.id} />
             {isInPurgatory === true ? (
               <Alert
                 title={content.asset.title}
@@ -61,7 +61,7 @@ export default function AssetContent({
               <>
                 <Markdown
                   className={styles.description}
-                  text={asset?.metadata?.description || ''}
+                  text={asset.metadata?.description || ''}
                   blockImages={!allowExternalContent}
                 />
                 <MetaSecondary ddo={asset} />
@@ -74,16 +74,42 @@ export default function AssetContent({
         </div>
 
         <div className={styles.actions}>
-          <AssetActions asset={asset} />
+          {!asset.accessDetails ? (
+            <p>Loading access details...</p>
+          ) : (
+            <>
+              {selectedService === -1 ? (
+                <>
+                  <h3>Available services:</h3>
+                  {asset.services.map((service, index) => (
+                    <ServiceCard
+                      key={service.id}
+                      service={service}
+                      accessDetails={asset.accessDetails[index]}
+                      onClick={() => setSelectedService(index)}
+                    />
+                  ))}
+                </>
+              ) : (
+                <AssetActions
+                  asset={asset}
+                  service={asset.services[selectedService]}
+                  accessDetails={asset.accessDetails[selectedService]}
+                  serviceIndex={selectedService}
+                  handleBack={() => setSelectedService(-1)}
+                />
+              )}
+            </>
+          )}
           {isOwner && isAssetNetwork && (
             <div className={styles.ownerActions}>
-              <Button style="text" size="small" to={`/asset/${asset?.id}/edit`}>
+              <Button style="text" size="small" to={`/asset/${asset.id}/edit`}>
                 Edit Asset
               </Button>
             </div>
           )}
           <Web3Feedback
-            networkId={asset?.chainId}
+            networkId={asset.chainId}
             accountId={accountId}
             isAssetNetwork={isAssetNetwork}
           />

--- a/src/components/Publish/Preview/index.tsx
+++ b/src/components/Publish/Preview/index.tsx
@@ -14,26 +14,28 @@ export default function Preview(): ReactElement {
     async function makeDdo() {
       const asset = (await transformPublishFormToDdo(values)) as AssetExtended
       // dummy BestPrice to trigger certain AssetActions
-      asset.accessDetails = {
-        type: values.pricing.type,
-        addressOrId: ZERO_ADDRESS,
-        templateId: 1,
-        price: `${values.pricing.price}`,
-        baseToken: {
-          address: ZERO_ADDRESS,
-          name: values.pricing?.baseToken?.symbol || 'OCEAN',
-          symbol: values.pricing?.baseToken?.symbol || 'OCEAN'
-        },
-        datatoken: {
-          address: ZERO_ADDRESS,
-          name: '',
-          symbol: ''
-        },
-        isPurchasable: true,
-        isOwned: false,
-        validOrderTx: '',
-        publisherMarketOrderFee: '0'
-      }
+      asset.accessDetails = [
+        {
+          type: values.pricing.type,
+          addressOrId: ZERO_ADDRESS,
+          templateId: 1,
+          price: `${values.pricing.price}`,
+          baseToken: {
+            address: ZERO_ADDRESS,
+            name: values.pricing?.baseToken?.symbol || 'OCEAN',
+            symbol: values.pricing?.baseToken?.symbol || 'OCEAN'
+          },
+          datatoken: {
+            address: ZERO_ADDRESS,
+            name: '',
+            symbol: ''
+          },
+          isPurchasable: true,
+          isOwned: false,
+          validOrderTx: '',
+          publisherMarketOrderFee: '0'
+        }
+      ]
       asset.stats = {
         orders: null,
         price: {

--- a/src/components/Publish/Preview/index.tsx
+++ b/src/components/Publish/Preview/index.tsx
@@ -22,7 +22,7 @@ export default function Preview(): ReactElement {
           price: `${values.pricing.price}`,
           baseToken: {
             address: ZERO_ADDRESS,
-            name: values.pricing?.baseToken?.symbol || 'OCEAN',
+            name: values.pricing?.baseToken?.name || 'Ocean Token',
             symbol: values.pricing?.baseToken?.symbol || 'OCEAN'
           },
           datatoken: {


### PR DESCRIPTION
## What was done?
- support multiple services when viewing and downloading the asset (compute type was not tested). Edit asset was not updated yet
- `AccessDetails` type on `AssetExtended` was changed to an array (1 accessDetails per each service)
- AccessDetails are filled from `offchain` metadata ([link](https://github.com/oceanprotocol/ocean-node/issues/525) to ocean-node issue). Previously it was fetched from Subgraph which is no longer supported in ocean-node

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/93ce7efb-d3e7-4816-aa0a-b11ab45fa787">

<hr/>
 
To publish an asset with multiple services you can use ocean-cli - this [PR](https://github.com/oceanprotocol/ocean-cli/pull/69) can help you. You need to do 3 steps:
1. publish asset
2. addService
3. edit metadata to contain offchain


## What is missing?
- downloading 2nd, 3rd, ... service doesn't work. [Issue](https://github.com/oceanprotocol/ocean-node/issues/555) created in ocean-node
- filling rest of AccessDetails with real data (templateId, isPurchasable, isOwned, validOrderTx, ...)
- testing consuming compute services
- editing asset (editing services)
