### PR TITLE
fix: provider fee balances for free assets

### DIFF
--- a/src/@utils/wallet/index.ts
+++ b/src/@utils/wallet/index.ts
@@ -220,3 +220,39 @@ export async function getTokenInfo(
     }
   }
 }
+
+/**
+ * Fetches on-chain token balances for a set of token addresses.
+ * Returns a map of lowercased symbol -> balance string.
+ * Use this for tokens that may not be in the pre-configured approved list.
+ */
+export async function fetchTokenBalancesByAddress(
+  accountId: string,
+  tokenAddresses: string[],
+  web3Provider: Provider
+): Promise<Record<string, string>> {
+  const result: Record<string, string> = {}
+  if (!accountId || !web3Provider || !tokenAddresses?.length) return result
+
+  const uniqueAddresses = [
+    ...new Set(tokenAddresses.map((a) => a.toLowerCase()))
+  ]
+
+  await Promise.allSettled(
+    uniqueAddresses.map(async (address) => {
+      const info = await getTokenInfo(address, web3Provider)
+      if (!info?.symbol || !info?.decimals) return
+      const bal = await getTokenBalance(
+        accountId,
+        info.decimals,
+        address,
+        web3Provider
+      )
+      if (bal) {
+        result[info.symbol.toLowerCase()] = bal
+      }
+    })
+  )
+
+  return result
+}

--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -52,7 +52,7 @@ import styles from './index.module.css'
 
 import { getDownloadValidationSchema } from './_validation'
 import { getDefaultValues } from '../ConsumerParameters/FormConsumerParameters'
-import { getTokenInfo } from '@utils/wallet'
+import { getTokenInfo, getTokenBalance } from '@utils/wallet'
 import useBalance from '@hooks/useBalance'
 import { getConsumeMarketFeeWei } from '@utils/consumeMarketFee'
 
@@ -103,6 +103,7 @@ export default function Download({
   const [insufficientSymbol, setInsufficientSymbol] = useState<string | null>(
     null
   )
+  const [providerFeeBalance, setProviderFeeBalance] = useState<string>('0')
 
   const [isFullPriceLoading, setIsFullPriceLoading] = useState(
     accessDetails.type !== 'free'
@@ -159,11 +160,19 @@ export default function Download({
   useEffect(() => {
     const fetchTokenDetailsProviderFee = async () => {
       if (!chainId || !signer?.provider) return
-      const tokenDetails = await getTokenInfo(
-        orderPriceAndFees?.providerFee?.providerFeeToken,
-        signer.provider
-      )
+      const providerFeeToken = orderPriceAndFees?.providerFee?.providerFeeToken
+      const tokenDetails = await getTokenInfo(providerFeeToken, signer.provider)
       setTokenInfoProviderFee(tokenDetails)
+
+      if (accountId && tokenDetails?.decimals != null && providerFeeToken) {
+        const bal = await getTokenBalance(
+          accountId,
+          tokenDetails.decimals,
+          providerFeeToken,
+          signer.provider
+        )
+        setProviderFeeBalance(bal || '0')
+      }
     }
     if (
       orderPriceAndFees?.providerFee?.providerFeeAmount &&
@@ -171,7 +180,7 @@ export default function Download({
     ) {
       fetchTokenDetailsProviderFee()
     }
-  }, [chainId, signer, orderPriceAndFees])
+  }, [chainId, signer, orderPriceAndFees, accountId])
 
   useEffect(() => {
     const licenseMirrors =
@@ -439,9 +448,7 @@ export default function Download({
     const userBaseBalance = new Decimal(
       balance?.approved?.[price.tokenSymbol?.toLowerCase()] || 0
     )
-    const userProviderBalance = new Decimal(
-      balance?.approved?.[tokenInfoProviderFee?.symbol?.toLowerCase()] || 0
-    )
+    const userProviderBalance = new Decimal(providerFeeBalance || 0)
 
     const sufficient = areTokensSame
       ? userBaseBalance.greaterThanOrEqualTo(

--- a/src/components/ComputeWizard/Review/index.tsx
+++ b/src/components/ComputeWizard/Review/index.tsx
@@ -26,7 +26,11 @@ import { useMarketMetadata } from '@context/MarketMetadata'
 import { getAccessDetails } from '@utils/accessDetailsAndPricing'
 import { getFixedBuyPrice } from '@utils/ocean/fixedRateExchange'
 import { getOceanConfig } from '@utils/ocean'
-import { getTokenInfo, getTokenBalanceFromSymbol } from '@utils/wallet'
+import {
+  getTokenInfo,
+  getTokenBalanceFromSymbol,
+  fetchTokenBalancesByAddress
+} from '@utils/wallet'
 import { compareAsBN } from '@utils/numbers'
 import { requiresSsi } from '@utils/credentials'
 import { getFeeTooltip } from '@utils/feeTooltips'
@@ -251,6 +255,9 @@ export default function Review({
   >([])
   const [algorithmProviderFeeEntries, setAlgorithmProviderFeeEntries] =
     useState<TotalPriceEntry[]>([])
+  const [providerFeeTokenBalances, setProviderFeeTokenBalances] = useState<
+    Record<string, string>
+  >({})
   const [algoLoadError, setAlgoLoadError] = useState<string>()
 
   const handleTermsChange = useCallback(
@@ -1333,6 +1340,27 @@ export default function Review({
       if (cancelled) return
       setDatasetProviderFeeEntries(datasetEntries)
       setAlgorithmProviderFeeEntries(algorithmEntries)
+
+      // Dynamically fetch balances for provider fee tokens
+      if (accountId && provider) {
+        const allFees = [
+          ...(datasetProviderFees || []),
+          ...(algorithmProviderFees ? [algorithmProviderFees] : [])
+        ]
+        const tokenAddresses = allFees
+          .map((f) => f?.providerFeeToken)
+          .filter(Boolean)
+        if (tokenAddresses.length > 0) {
+          const balances = await fetchTokenBalancesByAddress(
+            accountId,
+            tokenAddresses,
+            provider
+          )
+          if (!cancelled) {
+            setProviderFeeTokenBalances(balances)
+          }
+        }
+      }
     }
 
     loadProviderFees()
@@ -1344,7 +1372,8 @@ export default function Review({
     datasetProviderFees,
     algorithmProviderFees,
     signer?.provider,
-    resolveSymbol
+    resolveSymbol,
+    accountId
   ])
 
   useEffect(() => {
@@ -1358,8 +1387,13 @@ export default function Review({
       available: string
     }> = []
     for (const price of filteredPriceChecks) {
-      const baseTokenBalance =
+      const approvedBalance =
         getTokenBalanceFromSymbol(balance, price.symbol) || '0'
+      const dynamicBalance =
+        providerFeeTokenBalances[price.symbol?.toLowerCase()] || '0'
+      const baseTokenBalance = compareAsBN(approvedBalance, dynamicBalance)
+        ? approvedBalance
+        : dynamicBalance
       if (!compareAsBN(baseTokenBalance, price.value)) {
         sufficient = false
         if (!missingBalances.some((entry) => entry.symbol === price.symbol)) {
@@ -1377,7 +1411,12 @@ export default function Review({
     }
     setInsufficientBalances(missingBalances)
     setIsBalanceSufficient(sufficient)
-  }, [balance, totalPriceBreakdown, setIsBalanceSufficient])
+  }, [
+    balance,
+    totalPriceBreakdown,
+    setIsBalanceSufficient,
+    providerFeeTokenBalances
+  ])
 
   useEffect(() => {
     const allVerified =


### PR DESCRIPTION
Fixes provider fee balance checks failing for free assets by fetching token balances directly from the chain instead of relying on preloaded approved token list.

## Changes:
- Add `fetchTokenBalancesByAddress()` utility to fetch on-chain balances for arbitrary token addresses
- **Download flow:** Fetch provider fee token balance directly from chain instead of relying on approved token list
- **Compute wizard:** Dynamically fetch balances for all provider fee tokens and use the higher of approved vs. on-chain balance in sufficiency checks

Fixes #345 