### PR TITLE
Fix: remove rpc fallbacks

### DIFF
--- a/src/@utils/wallet/chains.ts
+++ b/src/@utils/wallet/chains.ts
@@ -1,6 +1,7 @@
 import { Chain } from 'wagmi/chains'
 import * as wagmiChains from 'wagmi/chains'
 import { getNodeUriMap } from '../runtimeConfig'
+import { LoggerInstance } from '@oceanprotocol/lib'
 
 // Custom OP Sepolia chain
 const opSepolia: Chain = {
@@ -38,8 +39,17 @@ const ethereumHoodi: Chain = {
   testnet: true
 }
 
+// Chain IDs of custom chains defined in this file whose hardcoded
+// RPC URLs are considered intentionally configured and GDPR-approved.
+const customChainIds = new Set([opSepolia.id, ethereumHoodi.id])
+
 /**
- * Returns wagmi-compatible chains filtered by allowed chain IDs
+ * Returns wagmi-compatible chains filtered by allowed chain IDs.
+ *
+ * GDPR enforcement: viem built-in chains (e.g. mainnet, optimism) ship
+ * with public RPC URLs we do not control. They are only included when a
+ * custom RPC is provided via NEXT_PUBLIC_NODE_URI_MAP. Custom chains
+ * defined above are treated as approved and always pass through.
  */
 export const getSupportedChains = (chainIdsSupported: number[]): Chain[] => {
   // Convert wagmiChains module to array of Chain objects
@@ -50,21 +60,32 @@ export const getSupportedChains = (chainIdsSupported: number[]): Chain[] => {
 
   const rpcMap = getNodeUriMap()
 
-  // Filter chains by allowed IDs and override RPCs if set in env
-  const filteredChains = allChains
-    .filter((chain) => chainIdsSupported.includes(chain.id))
-    .map((chain) => {
-      const mappedRpc = rpcMap[chain.id.toString()]
-      if (mappedRpc) {
-        return {
-          ...chain,
-          rpcUrls: {
-            public: { http: [mappedRpc] },
-            default: { http: [mappedRpc] }
-          }
-        }
+  // Only keep chains that have an approved RPC: either a custom chain
+  // (hardcoded RPC we control) or a viem built-in with an env override.
+  const allowedChains = allChains.filter((chain) => {
+    if (!chainIdsSupported.includes(chain.id)) return false
+    if (customChainIds.has(chain.id)) return true
+    if (rpcMap[chain.id.toString()]) return true
+
+    LoggerInstance.warn(
+      `[chains] Chain ${chain.name} (${chain.id}) excluded: ` +
+        `no RPC configured via NEXT_PUBLIC_NODE_URI_MAP`
+    )
+    return false
+  })
+
+  // Apply env RPC overrides to chains that have one configured.
+  const mappedChains = allowedChains.map((chain) => {
+    const mappedRpc = rpcMap[chain.id.toString()]
+    if (!mappedRpc) return chain
+    return {
+      ...chain,
+      rpcUrls: {
+        public: { http: [mappedRpc] },
+        default: { http: [mappedRpc] }
       }
-      return chain
-    })
-  return filteredChains
+    }
+  })
+
+  return mappedChains
 }

--- a/src/@utils/wallet/chains.ts
+++ b/src/@utils/wallet/chains.ts
@@ -39,9 +39,9 @@ const ethereumHoodi: Chain = {
   testnet: true
 }
 
-// Chain IDs of custom chains defined in this file whose hardcoded
-// RPC URLs are considered intentionally configured and GDPR-approved.
-const customChainIds = new Set([opSepolia.id, ethereumHoodi.id])
+// Custom chains with intentionally configured, approved RPC URLs.
+const customChains: Chain[] = [opSepolia, ethereumHoodi]
+const customChainIds = new Set(customChains.map((chain) => chain.id))
 
 /**
  * Returns wagmi-compatible chains filtered by allowed chain IDs.
@@ -52,16 +52,17 @@ const customChainIds = new Set([opSepolia.id, ethereumHoodi.id])
  * defined above are treated as approved and always pass through.
  */
 export const getSupportedChains = (chainIdsSupported: number[]): Chain[] => {
-  // Convert wagmiChains module to array of Chain objects
-  const baseChains: Chain[] = Object.values(wagmiChains)
+  // Convert wagmiChains module to array of Chain objects, excluding any
+  // that share an ID with a custom chain so the custom definition (with
+  // its approved RPC) is used instead of the wagmi-bundled public RPC.
+  const baseChains: Chain[] = Object.values(wagmiChains).filter(
+    (chain) => !customChainIds.has(chain.id)
+  )
 
-  // Include custom chains
-  const allChains = [...baseChains, opSepolia, ethereumHoodi]
+  const allChains = [...baseChains, ...customChains]
 
   const rpcMap = getNodeUriMap()
 
-  // Only keep chains that have an approved RPC: either a custom chain
-  // (hardcoded RPC we control) or a viem built-in with an env override.
   const allowedChains = allChains.filter((chain) => {
     if (!chainIdsSupported.includes(chain.id)) return false
     if (customChainIds.has(chain.id)) return true


### PR DESCRIPTION
Fixes #380 

Prevents silent connections to uncontrolled public RPC endpoints.

**Changes:**
- **chains.ts**: Exclude viem built-in chains unless a custom RPC is provided via `NEXT_PUBLIC_NODE_URI_MAP`. Custom chains with hardcoded approved RPCs always pass through. Logs a warning for excluded chains.