### PR TITLE
feat: implement CSRF protection and security headers in API routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,22 +26,6 @@ const securityHeaders = [
   {
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload'
-  },
-  {
-    key: 'X-Content-Type-Options',
-    value: 'nosniff'
-  },
-  {
-    key: 'X-Frame-Options',
-    value: 'DENY'
-  },
-  {
-    key: 'Referrer-Policy',
-    value: 'strict-origin-when-cross-origin'
-  },
-  {
-    key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=()'
   }
 ]
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,34 +1,6 @@
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
 
-const isDevelopment = process.env.NODE_ENV !== 'production'
-
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  `script-src 'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ''}`,
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https:",
-  "connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* http://172.15.0.4:* http://172.15.0.5:* http://172.15.0.15:* ws://localhost:* ws://127.0.0.1:*",
-  "worker-src 'self' blob:",
-  "media-src 'self' blob: https:"
-].join('; ')
-
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: contentSecurityPolicy
-  },
-  {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=63072000; includeSubDomains; preload'
-  }
-]
-
 const nextConfig = {
   output: 'standalone',
   serverExternalPackages: ['wagmi', 'viem', 'connectkit'],
@@ -93,14 +65,6 @@ const nextConfig = {
         source: '/publish',
         destination: '/publish/1',
         permanent: true
-      }
-    ]
-  },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: securityHeaders
       }
     ]
   },

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,50 @@
 import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
 
+const isDevelopment = process.env.NODE_ENV !== 'production'
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  `script-src 'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ''}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https:",
+  "connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* http://172.15.0.4:* http://172.15.0.5:* http://172.15.0.15:* ws://localhost:* ws://127.0.0.1:*",
+  "worker-src 'self' blob:",
+  "media-src 'self' blob: https:"
+].join('; ')
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload'
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY'
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()'
+  }
+]
+
 const nextConfig = {
   output: 'standalone',
   serverExternalPackages: ['wagmi', 'viem', 'connectkit'],
@@ -65,6 +109,14 @@ const nextConfig = {
         source: '/publish',
         destination: '/publish/1',
         permanent: true
+      }
+    ]
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders
       }
     ]
   },

--- a/src/@utils/wallet/signerServerApi.ts
+++ b/src/@utils/wallet/signerServerApi.ts
@@ -1,4 +1,5 @@
 import type { Address, Hex } from 'viem'
+import { getCookieValue } from '../cookies'
 
 export type SignerServerNetwork = {
   chainId: number
@@ -21,6 +22,8 @@ export type SignerServerMessageInput = { message: string } | { rawMessage: Hex }
 
 const SIGNER_SERVER_HEALTH_PATH = 'health'
 const SIGNER_SERVER_HEALTHY_STATUS = 'ok'
+const CSRF_COOKIE_NAME = '__Host-csrf_token'
+const CSRF_HEADER_NAME = 'X-CSRF-Token'
 
 type SignerServerHealthResponse = {
   status?: string
@@ -30,11 +33,15 @@ async function signerServerRequest<T>(
   path: string,
   init?: RequestInit
 ): Promise<T> {
+  const method = init?.method?.toUpperCase() || 'GET'
+  const csrfToken = method === 'POST' ? getCookieValue(CSRF_COOKIE_NAME) : ''
+
   const response = await fetch(`/api/signer-server/${path}`, {
     ...init,
     credentials: 'same-origin',
     headers: {
       ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(csrfToken ? { [CSRF_HEADER_NAME]: csrfToken } : {}),
       ...(init?.headers || {})
     }
   })

--- a/src/pages/api/auth/_cookies.ts
+++ b/src/pages/api/auth/_cookies.ts
@@ -1,8 +1,11 @@
 /* eslint-disable camelcase */
+import crypto from 'crypto'
 import type { NextApiResponse } from 'next'
 
 const AUTH_COOKIE_NAMES = ['access_token', 'refresh_token', 'id_token'] as const
 const EXTRA_SESSION_COOKIE_NAMES = ['dfns_token'] as const
+export const CSRF_COOKIE_NAME = '__Host-csrf_token'
+export const CSRF_HEADER_NAME = 'x-csrf-token'
 export const DEFAULT_ACCESS_TOKEN_MAX_AGE = 3600
 const REFRESH_TOKEN_MAX_AGE = 30 * 24 * 60 * 60
 
@@ -39,6 +42,16 @@ function serializeSessionCookie(
   )}; Max-Age=${maxAge}; HttpOnly; Secure; SameSite=Lax; Path=/`
 }
 
+function serializeCsrfCookie(value: string, maxAge: number): string {
+  return `${CSRF_COOKIE_NAME}=${encodeURIComponent(
+    value
+  )}; Max-Age=${maxAge}; Secure; SameSite=Strict; Path=/`
+}
+
+function generateCsrfToken(): string {
+  return crypto.randomBytes(32).toString('base64url')
+}
+
 export function buildAuthCookieStrings(
   tokens: AuthTokens,
   loginSource?: string
@@ -55,6 +68,8 @@ export function buildAuthCookieStrings(
       ),
     tokens.id_token &&
       serializeCookie('id_token', tokens.id_token, REFRESH_TOKEN_MAX_AGE),
+    tokens.access_token &&
+      serializeCsrfCookie(generateCsrfToken(), accessTokenMaxAge),
     loginSource &&
       serializeSessionCookie('login_source', loginSource, REFRESH_TOKEN_MAX_AGE)
   ].filter(Boolean) as string[]
@@ -72,6 +87,7 @@ export function buildClearAuthCookieStrings({
   return [
     ...authCookieNames.map((name) => serializeCookie(name, '', 0)),
     ...EXTRA_SESSION_COOKIE_NAMES.map((name) => serializeCookie(name, '', 0)),
+    serializeCsrfCookie('', 0),
     serializeSessionCookie('login_source', '', 0)
   ].filter(Boolean) as string[]
 }

--- a/src/pages/api/signer-server/[...path].ts
+++ b/src/pages/api/signer-server/[...path].ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '../auth/_cookies'
 import { getOptionalStringClaim } from '../auth/_claims'
 import { getVerifiedSessionClaims } from '../auth/_session'
 
@@ -39,23 +40,31 @@ function buildSignerServerUrl(req: NextApiRequest, baseUrl: string): string {
   return url.toString()
 }
 
-function getBearerToken(req: NextApiRequest): string | undefined {
-  const { authorization } = req.headers
-  if (authorization?.startsWith('Bearer ')) {
-    return authorization.slice('Bearer '.length).trim() || undefined
-  }
-
-  return undefined
+function getHeaderValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] || '' : value || ''
 }
 
-function getAccessToken(req: NextApiRequest) {
-  const headerToken = getBearerToken(req)
-  if (headerToken) return headerToken
+function getRequestOrigin(req: NextApiRequest): string {
+  const host = getHeaderValue(req.headers.host)
+  const forwardedProto = getHeaderValue(req.headers['x-forwarded-proto'])
+  const protocol = forwardedProto.split(',')[0]?.trim() || 'https'
 
-  const cookieToken = req.cookies.access_token
-  if (cookieToken) return cookieToken
+  return `${protocol}://${host}`
+}
 
-  return undefined
+function isAllowedOrigin(req: NextApiRequest) {
+  const origin = getHeaderValue(req.headers.origin)
+  if (!origin) return true
+  return origin === getRequestOrigin(req)
+}
+
+function hasValidCsrfToken(req: NextApiRequest) {
+  if (req.method !== 'POST') return true
+
+  const cookieToken = req.cookies[CSRF_COOKIE_NAME]
+  const headerToken = getHeaderValue(req.headers[CSRF_HEADER_NAME])
+
+  return Boolean(cookieToken && headerToken && cookieToken === headerToken)
 }
 
 export default async function handler(
@@ -71,7 +80,11 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const accessToken = getAccessToken(req)
+  if (!isAllowedOrigin(req) || !hasValidCsrfToken(req)) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  const accessToken = req.cookies.access_token
   if (!accessToken) {
     return res.status(401).json({ error: 'Signer server login is required.' })
   }


### PR DESCRIPTION
## Summary

Hardened the signer-server auth flow by keeping bearer-token handling on the server side and adding CSRF protection for mutating signer-server requests.

## Changes

- Removed support for client-provided `Authorization: Bearer` headers in the signer-server proxy.
- The signer-server proxy now uses only the `access_token` from the secure HttpOnly cookie.
- Added a separate CSRF cookie for authenticated sessions.
- Updated frontend signer-server `POST` requests to send the CSRF value in `X-CSRF-Token`.
- Added server-side CSRF and same-origin validation before forwarding signer-server `POST` requests.

## Notes

The access token may still appear in browser DevTools because it is stored as a browser cookie, but application JavaScript cannot read it or manually pass it to the signer-server proxy.